### PR TITLE
Refactor erase table

### DIFF
--- a/lib/dynamocli/aws/stack.rb
+++ b/lib/dynamocli/aws/stack.rb
@@ -1,0 +1,86 @@
+require 'forwardable'
+
+module Dynamocli::AWS
+  class Stack
+    CLOUDFORMARTION = Aws::CloudFormation::Client
+    LOGGER = TTY::Logger
+
+    attr_reader :name, :resources, :template_body, :original_template, :template_without_table, :policy_body
+
+    extend Forwardable
+    def_delegators :stack_on_aws,
+                   :parameters, :capabilities, :role_arn, :rollback_configuration, :notification_arns, :tags
+
+    def initialize(table_name:, table_resource:, cloudformation: nil, logger: nil)
+      @table_name = table_name
+      @table_resource = table_resource
+      @cloudformation = cloudformation ||= CLOUDFORMARTION.new
+      @logger = logger ||= LOGGER.new
+
+      set_attributes_now_because_they_will_change
+    end
+
+    def current_status
+      cloudformation.describe_stacks(stack_name: stack_name)[0][0].stack_status
+    end
+
+    private
+
+    attr_reader :stack_on_aws
+
+    def set_attributes_now_because_they_will_change
+      set_name
+      set_stack_on_aws
+      set_resources
+      set_template_body
+      set_original_template
+      set_template_without_table
+      set_policy_body
+    end
+
+    def set_stack_name
+      @name ||= table_resource[:name]
+    end
+
+    def set_stack_on_aws
+      @stack_on_aws ||= cloudformation.describe_stacks(stack_name: name)[0][0]
+    end
+
+    def set_resources
+      @resources ||= cloudformation.describe_stack_resources(physical_resource_id: table_name).to_h
+    end
+
+    def set_template_body
+      @template_body ||= @cloudformation.get_template(stack_name: @name).to_h[:template_body]
+    end
+
+    def set_original_template
+      @original_template ||= parse_template(template_body)
+    end
+
+    def set_template_without_table
+      @template_without_table ||= parse_template(template_body).tap do |template_without_table|
+        tables = original_template["Resources"].select { |_, v| v["Type"] == "AWS::DynamoDB::Table" }
+        table = tables.find { |_, v| v["Properties"]["TableName"] == @table_name }
+
+        if tables.nil?
+          logger.error("table #{@table_name} not found in the #{@name} stack")
+          exit(42)
+        end
+
+        logical_resource_id = table.first
+        template_without_table["Resources"].delete(logical_resource_id)
+      end
+    end
+
+    def parse_template(template)
+      JSON.parse(template)
+    rescue JSON::ParserError
+      YAML.load(template)
+    end
+
+    def set_policy_body
+      @policy_body ||= cloudformation.get_stack_policy(stack_name: name).stack_policy_body
+    end
+  end
+end

--- a/lib/dynamocli/erase.rb
+++ b/lib/dynamocli/erase.rb
@@ -5,6 +5,7 @@ require "aws-sdk-dynamodb"
 require "aws-sdk-cloudformation"
 require "dynamocli/table/cloudformation_table"
 require "dynamocli/table/standalone_table"
+require "dynamocli/aws/erase"
 
 class Dynamocli::Erase
   LOGGER = TTY::Logger.new
@@ -63,7 +64,8 @@ class Dynamocli::Erase
     @dynamocli_table ||= if stack_resources.nil? || with_drift?
       Dynamocli::Table::StandaloneTable.new(table_name: table_name, table: table)
     else
-      Dynamocli::Table::CloudformationTable.new(table_name: table_name, table_resource: table_resource)
+      stack = Dynamocli::AWS::Stack.new(table_name: table_name, table_resource: table_resource)
+      Dynamocli::Table::CloudformationTable.new(table_name: table_name, stack: stack)
     end
   end
 

--- a/lib/dynamocli/erase.rb
+++ b/lib/dynamocli/erase.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "json"
-require "yaml"
 require "tty-logger"
 require "aws-sdk-dynamodb"
 require "aws-sdk-cloudformation"
+require "dynamocli/table/cloudformation_table"
+require "dynamocli/table/standalone_table"
 
 class Dynamocli::Erase
   LOGGER = TTY::Logger.new
@@ -17,11 +17,7 @@ class Dynamocli::Erase
     @cloudformation = Aws::CloudFormation::Client.new
     @table = Aws::DynamoDB::Table.new(@table_name)
 
-    set_schema
-
     @stack_resources = @cloudformation.describe_stack_resources(physical_resource_id: @table_name).to_h
-
-    set_stack_information
   rescue Aws::DynamoDB::Errors::ResourceNotFoundException => e
     LOGGER.error(e.message)
     exit(42)
@@ -38,89 +34,16 @@ class Dynamocli::Erase
 
   private
 
-  def set_schema
-    @schema = @dynamodb.describe_table(table_name: @table_name).to_h[:table].tap do |schema|
-      schema.delete(:table_status)
-      schema.delete(:creation_date_time)
-      schema.delete(:table_size_bytes)
-      schema.delete(:item_count)
-      schema.delete(:table_arn)
-      schema.delete(:table_id)
-      schema[:provisioned_throughput].delete(:number_of_decreases_today)
-      schema[:local_secondary_indexes]&.each do |lsi|
-        lsi.delete(:index_status)
-        lsi.delete(:index_size_bytes)
-        lsi.delete(:item_count)
-        lsi.delete(:index_arn)
-      end
-      schema[:global_secondary_indexes]&.each do |gsi|
-        gsi.delete(:index_status)
-        gsi.delete(:index_size_bytes)
-        gsi.delete(:item_count)
-        gsi.delete(:index_arn)
-        gsi[:provisioned_throughput].delete(:number_of_decreases_today)
-      end
-    end
-  end
-  
-  def set_stack_information
-    return if @stack_resources.nil?
-
-    set_stack_name
-    set_stack
-    set_templates
-  rescue Aws::CloudFormation::Errors::ValidationError => e
-    LOGGER.error(e.message)
-    exit(42)
-  end
-
-  def set_stack_name
-    table_resource = @stack_resources[:stack_resources].find do |resource|
-      resource[:physical_resource_id] == @table_name
-    end
-    @stack_name = table_resource[:stack_name]
-  end
-
-  def set_stack
-    @stack = @cloudformation.describe_stacks(stack_name: @stack_name)[0][0]
-  end
-
-  def set_templates
-    template_body = @cloudformation.get_template(stack_name: @stack_name).to_h[:template_body]
-    @original_template = parse_template(template_body)
-    @template_without_table = parse_template(template_body)
-
-    tables = @original_template["Resources"].select { |_, v| v["Type"] == "AWS::DynamoDB::Table" }
-    table = tables.find { |_, v| v["Properties"]["TableName"] == @table_name }
-
-    if tables.nil?
-      LOGGER.error("table #{@table_name} not found in the #{@stack_name} stack")
-      exit(42)
-    end
-
-    logical_resource_id = table.first
-    @template_without_table["Resources"].delete(logical_resource_id)
-  end
-
-  def parse_template(template)
-    JSON.parse(template)
-  rescue JSON::ParserError
-    YAML.load(template)
-  end
+  attr_reader :table_name, :table, :stack_resources
 
   def erase_table
-    if @stack_resources.nil? || @with_drift
-      check_if_user_wants_to_continue_with_recreation
-      delete_and_recreate_the_table
-    else
-      check_if_user_wants_to_continue_with_deployment
-      erase_table_through_cloudformation
-    end
+    check_if_user_wants_to_continue
+    dynamocli_table.erase
   end
 
-  def check_if_user_wants_to_continue_with_recreation
+  def check_if_user_wants_to_continue
     LOGGER.warn(
-      "You're going to drop and recreate your #{@table_name} table,\n" \
+      "#{dynamocli_table.alert_message_before_continue},\n" \
       "do you really want to continue?"
     )
     STDOUT.print("(anything other than 'y' will cancel) > ")
@@ -136,111 +59,21 @@ class Dynamocli::Erase
     "Erase of #{@table_name} table canceled"
   end
 
-  def delete_and_recreate_the_table
-    delete_table
-    wait_for_deletion_to_complete
-    create_table
-  end
-
-  def delete_table
-    LOGGER.info("Deleting the #{@table_name} table")
-
-    @table.delete
-
-    LOGGER.success("#{@table_name} table deleted")
-  end
-
-  def wait_for_deletion_to_complete
-    waiting_seconds = 0
-    while get_table_status == "DELETING"
-      LOGGER.info("Waiting for deletion to complete")
-      sleep waiting_seconds += 1
-    end
-  rescue Aws::DynamoDB::Errors::ResourceNotFoundException
-    true
-  end
-
-  def get_table_status
-    @dynamodb.describe_table(table_name: @table_name).table.table_status
-  end
-
-  def create_table
-    LOGGER.info("Creating the #{@table_name} table")
-
-    @dynamodb.create_table(@schema)
-
-    LOGGER.success("#{@table_name} table created")
-  end
-  
-  def check_if_user_wants_to_continue_with_deployment
-    LOGGER.warn(
-      "You are going to deploy and redeploy your #{@stack_name} stack\n" \
-      "to drop and recreate the #{@table_name} table, do you really want to continue?"
-    )
-    STDOUT.print("(anything other than 'y' will cancel) > ")
-
-    confirmation = STDIN.gets.strip
-    return if confirmation == "y"
-
-    LOGGER.info(abort_message)
-    exit(0)
-  end
-
-  def erase_table_through_cloudformation
-    deploy_stack_without_the_table
-    wait_for_deployment_to_complete
-    deploy_stack_with_the_original_template
-  end
-
-  def deploy_stack_without_the_table
-    LOGGER.info("Deploying the stack without the #{@table_name} table")
-
-    @cloudformation.update_stack(
-      stack_name: @stack_name,
-      template_body: @template_without_table.to_json,
-      parameters: @stack.parameters.map(&:to_h),
-      capabilities: @stack.capabilities,
-      role_arn: @stack.role_arn,
-      rollback_configuration: @stack.rollback_configuration.to_h,
-      stack_policy_body: get_stack_policy_body,
-      notification_arns: @stack.notification_arns,
-      tags: @stack.tags.map(&:to_h)
-    )
-
-    LOGGER.success("Stack deployed without the #{@table_name} table")
-  end
-
-  def get_stack_policy_body
-    @cloudformation.get_stack_policy(stack_name: @stack_name).stack_policy_body
-  end
-
-  def wait_for_deployment_to_complete
-    waiting_seconds = 0
-    while get_stack_status != "UPDATE_COMPLETE"
-      LOGGER.info("Waiting for deployment to complete")
-      sleep waiting_seconds += 1
+  def dynamocli_table
+    @dynamocli_table ||= if stack_resources.nil? || with_drift?
+      Dynamocli::Table::StandaloneTable.new(table_name: table_name, table: table)
+    else
+      Dynamocli::Table::CloudformationTable.new(table_name: table_name, table_resource: table_resource)
     end
   end
 
-  def get_stack_status
-    @cloudformation.describe_stacks(stack_name: @stack_name)[0][0].stack_status
+  def with_drift?
+    @with_drift
   end
 
-  def deploy_stack_with_the_original_template
-    LOGGER.info("Deploying the stack with the #{@table_name} table")
-
-    @cloudformation.update_stack(
-      stack_name: @stack_name,
-      template_body: @original_template.to_json,
-      parameters: @stack.parameters.map(&:to_h),
-      capabilities: @stack.capabilities,
-      role_arn: @stack.role_arn,
-      rollback_configuration: @stack.rollback_configuration.to_h,
-      stack_policy_body: get_stack_policy_body,
-      notification_arns: @stack.notification_arns,
-      tags: @stack.tags.map(&:to_h)
-    )
-
-    LOGGER.success("Stack deployed with the #{@table_name} table")
+  def table_resource
+    @table_resource ||= stack_resources[:stack_resources].find do |resource|
+      resource[:physical_resource_id] == @table_name
+    end
   end
 end

--- a/lib/dynamocli/table/cloudformation_table.rb
+++ b/lib/dynamocli/table/cloudformation_table.rb
@@ -26,9 +26,6 @@ module Dynamocli::Table
       deploy_stack_without_the_table
       wait_for_deployment_to_complete
       deploy_stack_with_the_original_template
-    rescue Aws::CloudFormation::Errors::ValidationError => e
-      logger.error(e.message)
-      exit(42)
     end
 
     private

--- a/lib/dynamocli/table/cloudformation_table.rb
+++ b/lib/dynamocli/table/cloudformation_table.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "aws-sdk-cloudformation"
+require "tty-logger"
+require "json"
+require "yaml"
+
+module Dynamocli::Table
+  class CloudformationTable
+    LOGGER = TTY::Logger.new
+
+    def initialize(table_name:, table_resource:, cloudformation: nil)
+      @table_name = table_name
+      @table_resource = table_resource
+      @cloudformation = cloudformation ||= Aws::CloudFormation::Client.new
+    end
+
+    def alert_message_before_continue
+      "You're going to deploy and redeploy your #{@stack_name} stack to drop and recreate the #{@table_name} table!"
+    end
+
+    def erase
+      set_all_stack_information_before_we_change_it
+      deploy_stack_without_the_table
+      wait_for_deployment_to_complete
+      deploy_stack_with_the_original_template
+    rescue Aws::CloudFormation::Errors::ValidationError => e
+      LOGGER.error(e.message)
+      exit(42)
+    end
+
+    private
+
+    attr_reader :table_name, :table_resource, :cloudformation, :stack, :stack_name,
+                :stack_resources, :template_body, :original_template, :template_without_table,
+                :stack_policy_body
+
+    def set_all_stack_information_before_we_change_it
+      set_stack
+      set_stack_name
+      set_stack_resources
+      set_template_body
+      set_original_template
+      set_template_without_table
+      set_stack_policy_body
+    end
+
+    def deploy_stack_without_the_table
+      LOGGER.info("Deploying the stack without the #{table_name} table")
+
+      cloudformation.update_stack(
+        stack_name: stack_name,
+        template_body: template_without_table.to_json,
+        parameters: stack.parameters.map(&:to_h),
+        capabilities: stack.capabilities,
+        role_arn: stack.role_arn,
+        rollback_configuration: stack.rollback_configuration.to_h,
+        stack_policy_body: stack_policy_body,
+        notification_arns: stack.notification_arns,
+        tags: stack.tags.map(&:to_h)
+      )
+
+      LOGGER.success("Stack deployed without the #{table_name} table")
+    end
+
+    def wait_for_deployment_to_complete
+      waiting_seconds = 0
+      while get_stack_status != "UPDATE_COMPLETE"
+        LOGGER.info("Waiting for deployment to complete")
+        sleep waiting_seconds += 1
+      end
+    end
+
+    def get_stack_status
+      cloudformation.describe_stacks(stack_name: stack_name)[0][0].stack_status
+    end
+
+    def deploy_stack_with_the_original_template
+      LOGGER.info("Deploying the stack with the #{table_name} table")
+
+      cloudformation.update_stack(
+        stack_name: stack_name,
+        template_body: original_template.to_json,
+        parameters: stack.parameters.map(&:to_h),
+        capabilities: stack.capabilities,
+        role_arn: stack.role_arn,
+        rollback_configuration: stack.rollback_configuration.to_h,
+        stack_policy_body: stack_policy_body,
+        notification_arns: stack.notification_arns,
+        tags: stack.tags.map(&:to_h)
+      )
+
+      LOGGER.success("Stack deployed with the #{table_name} table")
+    end
+
+    def set_stack
+      @stack ||= cloudformation.describe_stacks(stack_name: stack_name)[0][0]
+    end
+
+    def set_stack_name
+      @stack_name ||= table_resource[:stack_name]
+    end
+
+    def set_stack_resources
+      @stack_resources ||= cloudformation.describe_stack_resources(physical_resource_id: table_name).to_h
+    end
+
+    def set_template_body
+      @template_body ||= @cloudformation.get_template(stack_name: @stack_name).to_h[:template_body]
+    end
+
+    def set_original_template
+      @original_template ||= parse_template(template_body)
+    end
+
+    def set_template_without_table
+      @template_without_table ||= parse_template(template_body).tap do |template_without_table|
+        tables = original_template["Resources"].select { |_, v| v["Type"] == "AWS::DynamoDB::Table" }
+        table = tables.find { |_, v| v["Properties"]["TableName"] == @table_name }
+
+        if tables.nil?
+          LOGGER.error("table #{@table_name} not found in the #{@stack_name} stack")
+          exit(42)
+        end
+
+        logical_resource_id = table.first
+        template_without_table["Resources"].delete(logical_resource_id)
+      end
+    end
+
+    def parse_template(template)
+      JSON.parse(template)
+    rescue JSON::ParserError
+      YAML.load(template)
+    end
+
+    def set_stack_policy_body
+      @stack_policy_body ||= cloudformation.get_stack_policy(stack_name: stack_name).stack_policy_body
+    end
+  end
+end

--- a/lib/dynamocli/table/cloudformation_table.rb
+++ b/lib/dynamocli/table/cloudformation_table.rb
@@ -9,20 +9,20 @@ module Dynamocli::Table
   class CloudformationTable
     CLOUDFORMARTION = Aws::CloudFormation::Client
     LOGGER = TTY::Logger
+    DEPLOY_COMPLETED_KEY = "UPDATE_COMPLETE"
 
-    def initialize(table_name:, table_resource:, cloudformation: nil, logger: nil)
+    def initialize(table_name:, stack:, cloudformation: nil, logger: nil)
       @table_name = table_name
-      @table_resource = table_resource
+      @stack = stack
       @cloudformation = cloudformation ||= CLOUDFORMARTION.new
       @logger = logger ||= LOGGER.new
     end
 
     def alert_message_before_continue
-      "You're going to deploy and redeploy your #{@stack_name} stack to drop and recreate the #{@table_name} table!"
+      "You're going to deploy and redeploy your #{stack.name} stack to drop and recreate the #{@table_name} table!"
     end
 
     def erase
-      set_all_stack_information_before_we_change_it
       deploy_stack_without_the_table
       wait_for_deployment_to_complete
       deploy_stack_with_the_original_template
@@ -33,76 +33,19 @@ module Dynamocli::Table
 
     private
 
-    attr_reader :table_name, :table_resource, :cloudformation, :logger, :stack, :stack_name,
-                :stack_resources, :template_body, :original_template, :template_without_table,
-                :stack_policy_body
-
-    def set_all_stack_information_before_we_change_it
-      set_stack
-      set_stack_name
-      set_stack_resources
-      set_template_body
-      set_original_template
-      set_template_without_table
-      set_stack_policy_body
-    end
-
-    def set_stack
-      @stack ||= cloudformation.describe_stacks(stack_name: stack_name)[0][0]
-    end
-
-    def set_stack_name
-      @stack_name ||= table_resource[:stack_name]
-    end
-
-    def set_stack_resources
-      @stack_resources ||= cloudformation.describe_stack_resources(physical_resource_id: table_name).to_h
-    end
-
-    def set_template_body
-      @template_body ||= @cloudformation.get_template(stack_name: @stack_name).to_h[:template_body]
-    end
-
-    def set_original_template
-      @original_template ||= parse_template(template_body)
-    end
-
-    def set_template_without_table
-      @template_without_table ||= parse_template(template_body).tap do |template_without_table|
-        tables = original_template["Resources"].select { |_, v| v["Type"] == "AWS::DynamoDB::Table" }
-        table = tables.find { |_, v| v["Properties"]["TableName"] == @table_name }
-
-        if tables.nil?
-          logger.error("table #{@table_name} not found in the #{@stack_name} stack")
-          exit(42)
-        end
-
-        logical_resource_id = table.first
-        template_without_table["Resources"].delete(logical_resource_id)
-      end
-    end
-
-    def parse_template(template)
-      JSON.parse(template)
-    rescue JSON::ParserError
-      YAML.load(template)
-    end
-
-    def set_stack_policy_body
-      @stack_policy_body ||= cloudformation.get_stack_policy(stack_name: stack_name).stack_policy_body
-    end
+    attr_reader :table_name, :stack, :cloudformation, :logger
 
     def deploy_stack_without_the_table
       logger.info("Deploying the stack without the #{table_name} table")
 
       cloudformation.update_stack(
-        stack_name: stack_name,
-        template_body: template_without_table.to_json,
+        stack_name: stack.name,
+        template_body: stack.template_without_table.to_json,
         parameters: stack.parameters.map(&:to_h),
         capabilities: stack.capabilities,
         role_arn: stack.role_arn,
         rollback_configuration: stack.rollback_configuration.to_h,
-        stack_policy_body: stack_policy_body,
+        stack_policy_body: stack.policy_body,
         notification_arns: stack.notification_arns,
         tags: stack.tags.map(&:to_h)
       )
@@ -112,27 +55,23 @@ module Dynamocli::Table
 
     def wait_for_deployment_to_complete
       waiting_seconds = 0
-      while get_stack_status != "UPDATE_COMPLETE"
+      while stack.current_status != DEPLOY_COMPLETED_KEY
         logger.info("Waiting for deployment to complete")
         sleep waiting_seconds += 1
       end
-    end
-
-    def get_stack_status
-      cloudformation.describe_stacks(stack_name: stack_name)[0][0].stack_status
     end
 
     def deploy_stack_with_the_original_template
       logger.info("Deploying the stack with the #{table_name} table")
 
       cloudformation.update_stack(
-        stack_name: stack_name,
-        template_body: original_template.to_json,
+        stack_name: stack.name,
+        template_body: stack.original_template.to_json,
         parameters: stack.parameters.map(&:to_h),
         capabilities: stack.capabilities,
         role_arn: stack.role_arn,
         rollback_configuration: stack.rollback_configuration.to_h,
-        stack_policy_body: stack_policy_body,
+        stack_policy_body: stack.policy_body,
         notification_arns: stack.notification_arns,
         tags: stack.tags.map(&:to_h)
       )

--- a/lib/dynamocli/table/standalone_table.rb
+++ b/lib/dynamocli/table/standalone_table.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "aws-sdk-dynamodb"
+require "tty-logger"
+
+module Dynamocli::Table
+  class StandaloneTable
+    LOGGER = TTY::Logger.new
+
+    def initialize(table_name:, table:, dynamodb: nil)
+      @table_name = table_name
+      @table = table
+      @dynamodb = dynamodb || Aws::DynamoDB::Client.new
+    end
+
+    def alert_message_before_continue
+      "You're going to drop and recreate your #{@table_name} table!"
+    end
+
+    def erase
+      delete_table
+      wait_for_deletion_to_complete
+      create_table
+    end
+
+    private
+
+    attr_reader :table_name, :table, :dynamodb, :schema
+
+    def delete_table
+      LOGGER.info("Deleting the #{table_name} table")
+
+      set_schema_before_we_delete_the_table
+      table.delete
+
+      LOGGER.success("#{table_name} table deleted")
+    end
+
+    def wait_for_deletion_to_complete
+      waiting_seconds = 0
+      while get_table_status == "DELETING"
+        LOGGER.info("Waiting for deletion to complete")
+        sleep waiting_seconds += 1
+      end
+    rescue Aws::DynamoDB::Errors::ResourceNotFoundException
+      true
+    end
+
+    def get_table_status
+      dynamodb.describe_table(table_name: table_name).table.table_status
+    end
+
+    def create_table
+      LOGGER.info("Creating the #{table_name} table")
+
+      dynamodb.create_table(schema)
+
+      LOGGER.success("#{table_name} table created")
+    end
+
+    def set_schema_before_we_delete_the_table
+      @schema ||= dynamodb.describe_table(table_name: table_name).to_h[:table].tap do |schema|
+        schema.delete(:table_status)
+        schema.delete(:creation_date_time)
+        schema.delete(:table_size_bytes)
+        schema.delete(:item_count)
+        schema.delete(:table_arn)
+        schema.delete(:table_id)
+        schema[:provisioned_throughput].delete(:number_of_decreases_today)
+        schema[:local_secondary_indexes]&.each do |lsi|
+          lsi.delete(:index_status)
+          lsi.delete(:index_size_bytes)
+          lsi.delete(:item_count)
+          lsi.delete(:index_arn)
+        end
+        schema[:global_secondary_indexes]&.each do |gsi|
+          gsi.delete(:index_status)
+          gsi.delete(:index_size_bytes)
+          gsi.delete(:item_count)
+          gsi.delete(:index_arn)
+          gsi[:provisioned_throughput].delete(:number_of_decreases_today)
+        end
+      end
+    end
+  end
+end

--- a/spec/dynamocli/table/cloudformation_table_spec.rb
+++ b/spec/dynamocli/table/cloudformation_table_spec.rb
@@ -1,34 +1,51 @@
 require "dynamocli/table/cloudformation_table"
 
 RSpec.describe Dynamocli::Table::CloudformationTable do
-  let(:cloudformation) { instance_double(described_class::CLOUDFORMARTION) }
-  let(:logger) { instance_double(described_class::LOGGER) }
+  let(:stack) { double("Dynamocli::AWS::Stack").as_null_object }
+  let(:cloudformation) { instance_double(described_class::CLOUDFORMARTION).as_null_object }
+  let(:logger) { instance_double(described_class::LOGGER).as_null_object }
+
+  subject do
+    described_class.new(
+      table_name: "users",
+      stack: stack,
+      cloudformation: cloudformation,
+      logger: logger
+    )
+  end
 
   describe "#erase" do
-    context "when CloudFormation library raises an Aws::CloudFormation::Errors::ValidationError exception" do
-      subject do
-        described_class.new(
-          table_name: "users",
-          table_resource: double("AWS::DynamoDB::Table"),
-          cloudformation: cloudformation,
-          logger: logger
-        )
-      end
+    context "when deploying the stack without the table" do
+      let(:template_without_table) { "Pretend I am the template without the table." }
 
       before do
-        allow(cloudformation).to receive(:describe_stacks).and_raise(Aws::CloudFormation::Errors::ValidationError.new("foo", "bar"))
+        allow(stack).to receive(:current_status).and_return(described_class::DEPLOY_COMPLETED_KEY)
+        allow(stack).to receive(:template_without_table).and_return(template_without_table)
       end
 
-      it "logs the error" do
-        allow(subject).to receive(:exit)
+      it "calls the update_stack method in the cloudformation library with the template without the table" do
+        expect(cloudformation).to receive(:update_stack).with(hash_including(template_body: template_without_table.to_json))
+        subject.erase
+      end
+    end
 
-        expect(logger).to receive(:error)
+    context "when deploying the stack again with the table" do
+      let(:original_template) { "Pretend I am the original template." }
+
+      before do
+        allow(subject).to receive(:sleep)
+        allow(stack).to receive(:current_status).and_return("foobar", described_class::DEPLOY_COMPLETED_KEY)
+        allow(stack).to receive(:original_template).and_return(original_template)
+      end
+
+      it "waits the first deployment to finish before calling update_stack method in the cloudformation library" do
+        expect(subject).to receive(:sleep)
         subject.erase
       end
 
-      it "exists with an error code greater than 0" do
-        allow(logger).to receive(:error).with(String)
-        expect { subject.erase }.to raise_exception(SystemExit)
+      it "calls the update_stack method in the cloudformation library with the original template" do
+        expect(cloudformation).to receive(:update_stack).with(hash_including(template_body: original_template.to_json))
+        subject.erase
       end
     end
   end

--- a/spec/dynamocli/table/cloudformation_table_spec.rb
+++ b/spec/dynamocli/table/cloudformation_table_spec.rb
@@ -1,0 +1,35 @@
+require "dynamocli/table/cloudformation_table"
+
+RSpec.describe Dynamocli::Table::CloudformationTable do
+  let(:cloudformation) { instance_double(described_class::CLOUDFORMARTION) }
+  let(:logger) { instance_double(described_class::LOGGER) }
+
+  describe "#erase" do
+    context "when CloudFormation library raises an Aws::CloudFormation::Errors::ValidationError exception" do
+      subject do
+        described_class.new(
+          table_name: "users",
+          table_resource: double("AWS::DynamoDB::Table"),
+          cloudformation: cloudformation,
+          logger: logger
+        )
+      end
+
+      before do
+        allow(cloudformation).to receive(:describe_stacks).and_raise(Aws::CloudFormation::Errors::ValidationError.new("foo", "bar"))
+      end
+
+      it "logs the error" do
+        allow(subject).to receive(:exit)
+
+        expect(logger).to receive(:error)
+        subject.erase
+      end
+
+      it "exists with an error code greater than 0" do
+        allow(logger).to receive(:error).with(String)
+        expect { subject.erase }.to raise_exception(SystemExit)
+      end
+    end
+  end
+end


### PR DESCRIPTION
It was added two new classes that represent a simple table
(that was created alone probably through the console) and
a table inside a stack (a table that was created through CloudFormation).

With these two tables, it was possible to reduce code repeated
in some places. Also, if there is a bug when deleting a simple
table or a table in CloudFormation now it is easier to debug.